### PR TITLE
Strip References to dart:core Object from Typescript Class Implementation Clauses

### DIFF
--- a/lib/swid/backend/ts/tsClassPreamble.dart
+++ b/lib/swid/backend/ts/tsClassPreamble.dart
@@ -1,3 +1,4 @@
+import 'package:hydro_sdk/swid/ir/constPrimitives.dart';
 import 'package:hydro_sdk/swid/ir/swidClass.dart';
 import 'package:hydro_sdk/swid/ir/swidType.dart';
 import 'package:hydro_sdk/swid/transforms/ts/transformPrimitiveNamesToTs.dart';
@@ -10,10 +11,16 @@ class TsClassPreamble {
   TsClassPreamble({
     required this.swidClass,
   }) : superInterfaces = ([
-          swidClass.extendedClass != null
+          swidClass.extendedClass != null &&
+                  !isClassDartObject(
+                    swidClass: swidClass.extendedClass!,
+                  )
               ? "I${swidClass.extendedClass!.displayName}"
               : null,
           ...swidClass.mixedInClasses
+              .where((x) => !isClassDartObject(
+                    swidClass: x,
+                  ))
               .map(
                 (x) => transformPrimitiveNamesToTs(
                   swidType: SwidType.fromSwidClass(
@@ -24,6 +31,9 @@ class TsClassPreamble {
               .map((x) => "I${x.displayName}")
               .toList(),
           ...swidClass.implementedClasses
+              .where((x) => !isClassDartObject(
+                    swidClass: x,
+                  ))
               .map(
                 (x) => transformPrimitiveNamesToTs(
                   swidType: SwidType.fromSwidClass(

--- a/lib/swid/ir/constPrimitives.dart
+++ b/lib/swid/ir/constPrimitives.dart
@@ -10,6 +10,32 @@ import 'package:hydro_sdk/swid/ir/swidStaticConstFieldReference.dart';
 import 'package:hydro_sdk/swid/ir/swidType.dart';
 import 'package:hydro_sdk/swid/ir/swidTypeFormal.dart';
 
+bool _isConstPrimitive({
+  required SwidType swidType,
+  required SwidType constPrimitive,
+}) =>
+    swidType.name == constPrimitive.name &&
+    swidType.originalPackagePath == constPrimitive.originalPackagePath;
+
+bool isDartObject({
+  required SwidType swidType,
+}) =>
+    _isConstPrimitive(
+      swidType: swidType,
+      constPrimitive: const SwidType.fromSwidInterface(
+        swidInterface: dartObject,
+      ),
+    );
+
+bool isClassDartObject({
+  required SwidClass swidClass,
+}) =>
+    isDartObject(
+      swidType: SwidType.fromSwidClass(
+        swidClass: swidClass,
+      ),
+    );
+
 const dartObject = const SwidInterface(
   name: "Object",
   nullabilitySuffix: SwidNullabilitySuffix.none,


### PR DESCRIPTION
#454 
Depends on #484 