### PR TITLE
Stop Including dart:core Type in Typescript Reference Rewriting

### DIFF
--- a/lib/swid/ir/constPrimitives.dart
+++ b/lib/swid/ir/constPrimitives.dart
@@ -58,6 +58,47 @@ const dartNullableObject = const SwidInterface(
   referenceDeclarationKind: SwidReferenceDeclarationKind.classElement,
 );
 
+bool isDartType({
+  required SwidType swidType,
+}) =>
+    _isConstPrimitive(
+      swidType: swidType,
+      constPrimitive: const SwidType.fromSwidInterface(
+        swidInterface: dartType,
+      ),
+    ) ||
+    _isConstPrimitive(
+      swidType: swidType,
+      constPrimitive: const SwidType.fromSwidInterface(
+        swidInterface: dartNullableType,
+      ),
+    );
+
+bool isClassDartType({
+  required SwidClass swidClass,
+}) =>
+    isDartType(
+      swidType: SwidType.fromSwidClass(
+        swidClass: swidClass,
+      ),
+    );
+
+const dartType = const SwidInterface(
+  name: "Type",
+  nullabilitySuffix: SwidNullabilitySuffix.none,
+  originalPackagePath: "dart:core",
+  typeArguments: [],
+  referenceDeclarationKind: SwidReferenceDeclarationKind.classElement,
+);
+
+const dartNullableType = const SwidInterface(
+  name: "Type?",
+  nullabilitySuffix: SwidNullabilitySuffix.question,
+  originalPackagePath: "dart:core",
+  typeArguments: [],
+  referenceDeclarationKind: SwidReferenceDeclarationKind.classElement,
+);
+
 const dartDouble = const SwidInterface(
   name: "double",
   nullabilitySuffix: SwidNullabilitySuffix.none,

--- a/lib/swid/ir/util/rewriteClassReferencesToInterfaceReferences.dart
+++ b/lib/swid/ir/util/rewriteClassReferencesToInterfaceReferences.dart
@@ -16,12 +16,14 @@ String rewriteReferenceName({
 }) =>
     isDartObject(swidType: swidType)
         ? "Object"
-        : [
-            "I",
-            removeNullabilitySuffix(
-              str: swidType.name,
-            )
-          ].join("");
+        : isDartType(swidType: swidType)
+            ? "Type"
+            : [
+                "I",
+                removeNullabilitySuffix(
+                  str: swidType.name,
+                )
+              ].join("");
 
 SwidType rewriteClassReferencesToInterfaceReferences({
   required SwidType swidType,


### PR DESCRIPTION
#453 
Depends on #486 