### PR TITLE
Fix Protected Methods and Inherited Synthetic Property Accessors in Typescript Translation Units

### DIFF
--- a/lib/swid/backend/ts/analyses/tsClassMethodInjectionCandidates.dart
+++ b/lib/swid/backend/ts/analyses/tsClassMethodInjectionCandidates.dart
@@ -71,7 +71,6 @@ class TsClassMethodInjectionCandidates
                 swidFunctionType: x,
               ),
             )
-            .where((x) => !x.declarationModifiers.hasProtected)
             .toList(),
       );
 }

--- a/lib/swid/frontend/dart/swidClassFromInterfaceType.dart
+++ b/lib/swid/frontend/dart/swidClassFromInterfaceType.dart
@@ -86,8 +86,15 @@ SwidClass swidClassFromInterfaceType({
             .toList(),
         ...interfaceType.accessors
             .whereType<PropertyAccessorElement>()
-            .where((x) => x.name[0] != "_")
-            .where((x) => !x.isStatic)
+            .where(
+              (x) => x.name[0] != "_",
+            )
+            .where(
+              (x) => !x.isStatic,
+            )
+            .where(
+              (x) => !x.isSynthetic,
+            )
             .map(
               (x) => swidFunctionTypeFromPropertyAccessor(
                 buildElements: buildElements,
@@ -97,7 +104,31 @@ SwidClass swidClassFromInterfaceType({
             .toList()
       ],
       staticConstFieldDeclarations: [],
-      instanceFieldDeclarations: {},
+      instanceFieldDeclarations: Map.fromEntries(
+        interfaceType.accessors
+            .whereType<PropertyAccessorElement>()
+            .where(
+              (x) => x.name[0] != "_",
+            )
+            .where(
+              (x) => !x.isStatic,
+            )
+            .where(
+              (x) => x.isSynthetic,
+            )
+            .where(
+              (x) => x.isGetter,
+            )
+            .map(
+              (x) => MapEntry(
+                x.name,
+                swidFunctionTypeFromPropertyAccessor(
+                  propertyAccessorElement: x,
+                  buildElements: buildElements,
+                ).returnType,
+              ),
+            ),
+      ),
       declarationModifiers: SwidDeclarationModifiers.empty(),
       mixedInClasses: interfaceType.mixins
           .map(


### PR DESCRIPTION
#719 